### PR TITLE
Add trollflow job scheduling logic

### DIFF
--- a/schedule-trollflow-k8s-job/schedule_troll_jobs.py
+++ b/schedule-trollflow-k8s-job/schedule_troll_jobs.py
@@ -12,7 +12,7 @@ from kubernetes import client, config
 # Environment variables
 JOB_SCHEDULER_DEBUG_LEVEL = os.getenv("JOB_SCHEDULER_DEBUG_LEVEL", "INFO")
 JOB_SCHEDULER_NAMESPACE = os.getenv("JOB_SCHEDULER_NAMESPACE", "nordsat-processing")
-JOB_SCHEDULER_IMAGE = os.getenv("JOB_SCHEDULER_IMAGE", "mraspaud/trollflow2-kub")
+JOB_SCHEDULER_IMAGE = os.getenv("JOB_SCHEDULER_IMAGE", "mraspaud/trollflow2-kub:1.0")
 TROLL_FLOW_CONFIGMAP_NAME = os.getenv(
     "JOB_SCHEDULER_TROLL_FLOW_CONFIGMAP_NAME", "satpy-test-fm"
 )


### PR DESCRIPTION
This PR introduced the logic to schedule jobs in Kubernetes. It can be used as standalone script. There are some env variables to provided.

JOB_SCHEDULER_COMMAND  needs to be adapted yet. And the container image to be used as well.

Tested the logic on a dev cluster with dummy loads and successfully created the job template and run it.

![Clipboard - June 1, 2023 10 12 AM](https://github.com/nordsat/ewc-config/assets/27498679/285c2471-acd9-4808-865f-eb79e9e1614b)
